### PR TITLE
CircleCI: copy self to build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,11 @@ jobs:
       - save_cache: *save_cache
       - run: bundle exec middleman build
       - run:
+          name: copy .circleci/config.yml to build
+          command: |
+            mkdir build/.circleci
+            cp .circleci/config.yml build/.circleci
+      - run:
           name: bundle exec middleman deploy
           command: |
             git config --global user.name 'circleci'
@@ -87,7 +92,10 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore: master
       - deploy:
           requires:
             - build


### PR DESCRIPTION
master ブランチで CircleCI 2.0 を起動しないようにする苦肉？の策